### PR TITLE
Fix signature generation for requests with payload

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import sha1 from 'sha1';
 
 export function signature(secret, url, payload) {
-  payload = payload ? JSON.stringify(payload) : '';
+  payload = payload ? sha1(JSON.stringify(payload)) : '';
 
   return sha1(secret + url + payload);
 }


### PR DESCRIPTION
According to the [documentation](https://rokka.io/documentation/guides/authentication.html), sha1 is needed around the body as well. Double-sha ;)