### PR TITLE
Make sure `babel-runtime` is installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ JavaScript client library for [rokka](https://rokka.io/).
 ## Install
 
 ```bash
-$ npm install rokka --save
+$ npm install rokka babel-runtime --save
 ```
 
 ## Usage


### PR DESCRIPTION
In newer versions of `npm`, peerDependencies are not automatically installed, and must be installed explicitly.

By making installation of `babel-runtime` explicit, this should work for all `npm` versions.